### PR TITLE
chore: remove unneded alias

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "scripts": {
     "rollup-dev": "rollup --config rollup.config.js -w",
     "rollup-build": "rollup --config rollup.config.js --environment BUILD:production",
-    "dev": "vite",
+    "dev": "vite build --watch",
     "build": "vite build"
   },
   "keywords": [],

--- a/vite.config.js
+++ b/vite.config.js
@@ -4,11 +4,6 @@ import vuePlugin from '@vitejs/plugin-vue'
 
 export default defineConfig({
   plugins: [vuePlugin()],
-  resolve: {
-    alias: {
-      'obsidian': '/obsidian-shim.js'
-    }
-  },
   build: {
     minify: false,
     // Use Vite lib mode https://vitejs.dev/guide/build.html#library-mode


### PR DESCRIPTION
That obsidian-shim.js sounded like quite a hack 😅 
It was part of trying something out, it is currently ignored because of 'obsidian' being marked as external